### PR TITLE
Add missing "repository" field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,5 +23,9 @@
   "engines": {
     "node": ">=0.10.0"
   },
-  "license": "ISC"
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jkimbo/eslint-plugin-jest.git"
+  }
 }


### PR DESCRIPTION
This makes it easier to find the github repo when viewing the package in the npm registry.