### PR TITLE
Update installation guide to use Yarn add command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Eslint plugin for Jest
 ## Installation
 
 ```
-$ yarn install eslint eslint-plugin-jest --dev
+$ yarn add eslint eslint-plugin-jest --dev
 ```
 
 **Note:** If you installed ESLint globally then you must also install `eslint-plugin-jest` globally.


### PR DESCRIPTION
When using install, the following warning is logged:

```
yarn install v0.18.1
error `install` has been replaced with `add` to add new dependencies. Run "yarn add mocha" instead.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```